### PR TITLE
Navigator 호출 수정

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -113,13 +113,17 @@ class _AuthStateListenerState extends State<AuthStateListener> {
 
               // 홈으로 이동 및 환영 메시지 표시
               WidgetsBinding.instance.addPostFrameCallback((_) {
-                if (mounted) {
-                  Navigator.of(
-                    context,
-                  ).pushNamedAndRemoveUntil('/home', (route) => false);
+                if (mounted && navigatorKey.currentContext != null) {
+                  navigatorKey.currentState?.pushNamedAndRemoveUntil(
+                    '/home',
+                    (route) => false,
+                  );
 
                   // 환영 메시지 표시
-                  ScaffoldMessenger.of(context).showSnackBar(
+                  var messenger = ScaffoldMessenger.of(
+                    navigatorKey.currentContext!,
+                  );
+                  messenger.showSnackBar(
                     const SnackBar(
                       content: Text('로그인 성공! 환영합니다! 🎉'),
                       backgroundColor: Colors.green,
@@ -130,8 +134,11 @@ class _AuthStateListenerState extends State<AuthStateListener> {
               });
             } catch (e) {
               WidgetsBinding.instance.addPostFrameCallback((_) {
-                if (mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
+                if (mounted && navigatorKey.currentContext != null) {
+                  var messenger = ScaffoldMessenger.of(
+                    navigatorKey.currentContext!,
+                  );
+                  messenger.showSnackBar(
                     SnackBar(
                       content: Text('로그인 처리 중 오류가 발생했습니다: ${e.toString()}'),
                       backgroundColor: Colors.redAccent,
@@ -143,10 +150,11 @@ class _AuthStateListenerState extends State<AuthStateListener> {
             }
           } else if (event == AuthChangeEvent.signedOut) {
             WidgetsBinding.instance.addPostFrameCallback((_) {
-              if (mounted) {
-                Navigator.of(
-                  context,
-                ).pushNamedAndRemoveUntil('/welcome', (route) => false);
+              if (mounted && navigatorKey.currentContext != null) {
+                navigatorKey.currentState?.pushNamedAndRemoveUntil(
+                  '/welcome',
+                  (route) => false,
+                );
               }
             });
           }


### PR DESCRIPTION
Navigator.of(context)가 호출될 때 context가 Navigator 하위에 있지 않아서 발생한 것으로 보임

AuthStateListener가 MaterialApp의 builder 내부에 있어서 Navigator가 생성되기전에 네비게이션을 시도함

그래서 context 대신 navigatorKey.currentState랑 navigatorKey.currentContext를 사용함